### PR TITLE
Update solution and project files to support Visual Studio 2022 and NVidia Cuda 12.6

### DIFF
--- a/VC_CUDA126/Kangaroo.sln
+++ b/VC_CUDA126/Kangaroo.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Kangaroo", "Kangaroo.vcxproj", "{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+		ReleaseSM30|x64 = ReleaseSM30|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.Debug|x64.ActiveCfg = Debug|x64
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.Debug|x64.Build.0 = Debug|x64
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.Release|x64.ActiveCfg = Release|x64
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.Release|x64.Build.0 = Release|x64
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.ReleaseSM30|x64.ActiveCfg = ReleaseSM30|x64
+		{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}.ReleaseSM30|x64.Build.0 = ReleaseSM30|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6D720311-0075-4355-907B-9404246E4B51}
+	EndGlobalSection
+EndGlobal

--- a/VC_CUDA126/Kangaroo.vcxproj
+++ b/VC_CUDA126/Kangaroo.vcxproj
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseSM30|x64">
+      <Configuration>ReleaseSM30</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Constants.h" />
+    <ClInclude Include="..\GPU\GPUCompute.h" />
+    <ClInclude Include="..\GPU\GPUEngine.h" />
+    <ClInclude Include="..\GPU\GPUMath.h" />
+    <ClInclude Include="..\HashTable.h" />
+    <ClInclude Include="..\SECPK1\Int.h" />
+    <ClInclude Include="..\SECPK1\IntGroup.h" />
+    <ClInclude Include="..\SECPK1\Point.h" />
+    <ClInclude Include="..\SECPK1\Random.h" />
+    <ClInclude Include="..\SECPK1\SECP256k1.h" />
+    <ClInclude Include="..\Timer.h" />
+    <ClInclude Include="..\Kangaroo.h" />
+    <ClInclude Include="..\WindowsErrors.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Backup.cpp" />
+    <ClCompile Include="..\Check.cpp" />
+    <ClCompile Include="..\HashTable.cpp" />
+    <ClCompile Include="..\Merge.cpp" />
+    <ClCompile Include="..\Network.cpp" />
+    <ClCompile Include="..\PartMerge.cpp" />
+    <ClCompile Include="..\SECPK1\Int.cpp" />
+    <ClCompile Include="..\SECPK1\IntGroup.cpp" />
+    <ClCompile Include="..\SECPK1\IntMod.cpp" />
+    <ClCompile Include="..\main.cpp" />
+    <ClCompile Include="..\SECPK1\Point.cpp" />
+    <ClCompile Include="..\SECPK1\Random.cpp" />
+    <ClCompile Include="..\SECPK1\SECP256K1.cpp" />
+    <ClCompile Include="..\Thread.cpp" />
+    <ClCompile Include="..\Timer.cpp" />
+    <ClCompile Include="..\Kangaroo.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <CudaCompile Include="..\GPU\GPUEngine.cu">
+      <CodeGeneration Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">compute_30,sm_30</CodeGeneration>
+      <CodeGeneration Condition="'$(Configuration)|$(Platform)'=='Release|x64'">compute_30,sm_30;compute_35,sm_35;compute_37,sm_37;compute_50,sm_50;compute_52,sm_52;compute_60,sm_60;compute_61,sm_61;compute_70,sm_70;compute_75,sm_75;</CodeGeneration>
+      <CodeGeneration Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'">compute_61,sm_61</CodeGeneration>
+      <PtxAsOptionV Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</PtxAsOptionV>
+      <PtxAsOptionV Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'">true</PtxAsOptionV>
+      <NvccCompilation Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'">compile</NvccCompilation>
+      <AdditionalCompilerOptions Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'">
+      </AdditionalCompilerOptions>
+    </CudaCompile>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9EA67A77-3F50-4FCE-85B9-FAB635FEFB0A}</ProjectGuid>
+    <RootNamespace>Kangaroo</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.6.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITHGPU;_CRT_SECURE_NO_WARNINGS;WIN32;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <CudaCompile>
+      <TargetMachinePlatform>64</TargetMachinePlatform>
+    </CudaCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITHGPU;_CRT_SECURE_NO_WARNINGS;WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;ws2_32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <CudaCompile>
+      <TargetMachinePlatform>64</TargetMachinePlatform>
+    </CudaCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSM30|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITHGPU;_CRT_SECURE_NO_WARNINGS;WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <CudaCompile>
+      <TargetMachinePlatform>64</TargetMachinePlatform>
+    </CudaCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.6.targets" />
+  </ImportGroup>
+</Project>

--- a/VC_CUDA126/Kangaroo.vcxproj.filters
+++ b/VC_CUDA126/Kangaroo.vcxproj.filters
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\main.cpp" />
+    <ClCompile Include="..\Timer.cpp" />
+    <ClCompile Include="..\HashTable.cpp" />
+    <ClCompile Include="..\Kangaroo.cpp" />
+    <ClCompile Include="..\SECPK1\Int.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\SECPK1\IntGroup.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\SECPK1\IntMod.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\SECPK1\Point.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\SECPK1\Random.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\SECPK1\SECP256K1.cpp">
+      <Filter>SECPK1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Thread.cpp" />
+    <ClCompile Include="..\Check.cpp" />
+    <ClCompile Include="..\Backup.cpp" />
+    <ClCompile Include="..\Network.cpp" />
+    <ClCompile Include="..\Merge.cpp" />
+    <ClCompile Include="..\PartMerge.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Timer.h" />
+    <ClInclude Include="..\HashTable.h" />
+    <ClInclude Include="..\Kangaroo.h" />
+    <ClInclude Include="..\SECPK1\Int.h">
+      <Filter>SECPK1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\SECPK1\IntGroup.h">
+      <Filter>SECPK1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\SECPK1\Point.h">
+      <Filter>SECPK1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\SECPK1\Random.h">
+      <Filter>SECPK1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\SECPK1\SECP256k1.h">
+      <Filter>SECPK1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GPU\GPUEngine.h">
+      <Filter>GPU</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GPU\GPUMath.h">
+      <Filter>GPU</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GPU\GPUCompute.h">
+      <Filter>GPU</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Constants.h" />
+    <ClInclude Include="..\WindowsErrors.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="SECPK1">
+      <UniqueIdentifier>{8caf15b2-3ab6-48c0-862b-ae72b7c23ca4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="GPU">
+      <UniqueIdentifier>{71f0de0a-b083-42b0-ad08-2182418491f0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CudaCompile Include="..\GPU\GPUEngine.cu">
+      <Filter>GPU</Filter>
+    </CudaCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add support for Visual Studio 2022 and NVidia Cuda 12.6 by creating new solution and project files in the `VC_CUDA126` directory.

* **New Solution File:**
  - Add `VC_CUDA126/Kangaroo.sln` based on `VC_CUDA102/Kangaroo.sln`.
  - Update to target Visual Studio 2022.

* **New Project File:**
  - Add `VC_CUDA126/Kangaroo.vcxproj` based on `VC_CUDA102/Kangaroo.vcxproj`.
  - Update to target NVidia Cuda 12.6 and Visual Studio 2022.
  - Include necessary configurations for Debug, Release, and ReleaseSM30.

* **New Project Filters File:**
  - Add `VC_CUDA126/Kangaroo.vcxproj.filters` based on `VC_CUDA102/Kangaroo.vcxproj.filters`.
  - Include necessary filters for SECPK1 and GPU.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pauldmurphy/Kangaroo?shareId=95afd0a2-8b7f-41c0-b353-ba24ac9c987d).